### PR TITLE
Fix nginx proxy path stripping for variable-based proxy_pass

### DIFF
--- a/docker/ui-nginx.conf
+++ b/docker/ui-nginx.conf
@@ -12,7 +12,8 @@ server {
 
     location /api/rule-engine/ {
         set $rule_engine_backend "__RULE_ENGINE_UPSTREAM__";
-        proxy_pass $rule_engine_backend/;
+        rewrite ^/api/rule-engine/(.*) /$1 break;
+        proxy_pass $rule_engine_backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -24,7 +25,8 @@ server {
 
     location /api/decision-center/ {
         set $decision_center_backend "__DECISION_CENTER_UPSTREAM__";
-        proxy_pass $decision_center_backend/;
+        rewrite ^/api/decision-center/(.*) /$1 break;
+        proxy_pass $decision_center_backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Variable-based `proxy_pass $var` doesn't strip the location prefix like literal `proxy_pass` does
- `/api/rule-engine/v1/groups` was being proxied as `/` instead of `/v1/groups` — returning 404
- `/api/decision-center/v1/logs/atomic` same issue — causing timeouts
- Fix: add explicit `rewrite` rules to strip the prefix before proxying

## Test plan
- [ ] Rule engine groups load in UI sidebar
- [ ] Decision log fetches successfully
- [ ] Test console works

🤖 Generated with [Claude Code](https://claude.com/claude-code)