### PR TITLE
Fix rate limiter to use real client IP behind Railway proxy

### DIFF
--- a/decision_center/app.py
+++ b/decision_center/app.py
@@ -9,7 +9,6 @@ import json
 
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 
 from .models import (
     DecisionOutcome, DecisionState, EvaluateRequest, DecisionResult,
@@ -27,7 +26,14 @@ logger = logging.getLogger(__name__)
 
 check_production_api_key()
 
-limiter = Limiter(key_func=get_remote_address, enabled=os.getenv("ENVIRONMENT") == "production")
+def _get_real_client_ip(request: Request) -> str:
+    """Use X-Forwarded-For when behind Railway's proxy, fall back to remote addr."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+limiter = Limiter(key_func=_get_real_client_ip, enabled=os.getenv("ENVIRONMENT") == "production")
 
 app = FastAPI(title="Unreal Objects Decision Center API")
 app.state.limiter = limiter


### PR DESCRIPTION
## Summary
- Rate limiter was keying on `get_remote_address` which returns Railway proxy IPs (`100.64.0.x`)
- Each proxy IP got its own 60/min bucket, allowing a single client ~1500 req/min total
- Bot flooding `/v1/decide` overwhelmed the DC, blocking all other requests including UI log fetches
- Fix: key on `X-Forwarded-For` header to rate limit by actual client IP

## Test plan
- [ ] All 121 DC tests pass
- [ ] Decision log loads in UI after deploy
- [ ] Bot traffic properly rate limited to 60/min per real IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)