### PR TITLE
fix: MCP server memory leak (stateless HTTP + token prune)

### DIFF
--- a/mcp_server/auth.py
+++ b/mcp_server/auth.py
@@ -155,6 +155,13 @@ class AuthService:
         self.token_ttl_seconds = token_ttl_seconds
         self._access_tokens: dict[str, AccessTokenRecord] = {}
 
+    def _prune_expired_tokens(self) -> None:
+        """Remove expired tokens so the in-memory dict doesn't grow unbounded."""
+        now = _utcnow()
+        expired = [t for t, r in self._access_tokens.items() if r.expires_at <= now]
+        for t in expired:
+            del self._access_tokens[t]
+
     def create_agent(self, name: str, description: str = "", metadata: dict[str, Any] | None = None) -> AgentRecord:
         agent = AgentRecord(name=name, description=description, metadata=metadata or {})
         self.store.data.agents[agent.agent_id] = agent
@@ -249,6 +256,7 @@ class AuthService:
         client_secret: str,
         requested_scope: str | None = None,
     ) -> AccessTokenIssue:
+        self._prune_expired_tokens()
         credential = next(
             (c for c in self.store.data.credentials.values() if c.client_id == client_id),
             None,

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -80,7 +80,7 @@ async def lifespan(server: FastMCP):
         yield Clients(rule_engine=re_client, decision_center=dc_client)
 
 
-mcp = FastMCP("Unreal Objects", lifespan=lifespan, instructions=_INSTRUCTIONS)
+mcp = FastMCP("Unreal Objects", lifespan=lifespan, instructions=_INSTRUCTIONS, stateless_http=True)
 
 
 def _clients(ctx: Context) -> Clients:


### PR DESCRIPTION
## Summary

- **Enable `stateless_http=True` on FastMCP** (`server.py:83`). The bot's mcporter tool calls are stateless — no session tracking needed. Without this, every MCP connection creates a `StreamableHTTPServerTransport` stored permanently in `_server_instances`, causing memory to climb from ~50 MB → 8 GB/hour.
- **Add `_prune_expired_tokens()` to `AuthService`** (`auth.py:158-162`). Called on every `issue_access_token()` so expired bearer tokens don't accumulate in the in-memory `_access_tokens` dict.

## Evidence

Railway metrics showed MCP service memory climbing linearly from ~2 GB to ~7 GB over 1 hour with near-zero CPU — classic leak. Root cause confirmed via code review of FastMCP's `streamable_http_manager.py:_server_instances` dict.

## Test plan

- [x] `pytest mcp_server/tests/ -v` — 63/63 passed
- [ ] Deploy to Railway, watch Memory metric for 1 hour — should flatline at ~50-100 MB instead of climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)