### PR TITLE
feat(ui): Dashboard screen + glassmorphism sidebar — day closing 2026-04-13 (2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,19 @@ A continuous simulator that generates realistic support cases at accelerated vir
 
 ### React UI (`ui/`)
 
-Vite + React + TypeScript + Tailwind CSS. Talks directly to Rule Engine (`:8001`) and Decision Center (`:8002`). Main components: `Sidebar` (group management), `ChatInterface` (LLM wizard for rule creation), `TestConsole` (action simulation), `DecisionLog` (audit trail viewer with expandable chain timelines).
+Vite + React + TypeScript + Tailwind CSS. Talks directly to Rule Engine (`:8001`) and Decision Center (`:8002`).
 
-The `ChatInterface` schema dropdown is dynamically populated from `GET /v1/schemas` on mount (previously a hardcoded constant). `AgentAdminPanel` includes an MCP config snippet generator with tabs for Claude Desktop (HTTP), Claude Desktop (stdio), Cursor/Windsurf, and Generic/Other clients, plus copy-to-clipboard.
+**App shell**: A persistent top header bar (`h-14`) contains a hamburger toggle and breadcrumb navigation (`Unreal Objects › View › Group`). The sidebar is a glassmorphism slide-over overlay (`bg-white/85 backdrop-blur-xl`) that opens from the burger button — no fixed desktop sidebar. Default view on load is `dashboard`.
+
+**Main views / components:**
+- `Dashboard` — default landing screen; service health badges (Rule Engine, Decision Center), stat cards (rule groups, total rules, pending approvals, decisions today), decision outcome progress bars, inline pending-approval approve/reject, recent decisions table (desktop) / card list (mobile). Auto-refreshes every 30 s.
+- `Sidebar` — glassmorphism overlay; single rendering path for all screen sizes. Props: `isOpen`, `onClose`, `activeView`, `onOpenDashboard`.
+- `ChatInterface` — LLM wizard for rule creation. Schema dropdown dynamically populated from `GET /v1/schemas` on mount.
+- `TestConsole` — action simulation against a rule group.
+- `DecisionLog` — audit trail viewer with expandable chain timelines and "Download JSON" export.
+- `AgentAdminPanel` — MCP config snippet generator (Claude Desktop HTTP/stdio, Cursor/Windsurf, Generic) with copy-to-clipboard.
+
+**Dashboard API functions** (`api.ts`): `fetchRuleEngineHealth()`, `fetchDecisionCenterHealth()` (3 s timeout probes returning `boolean`), `fetchPendingApprovals()`, `submitApprovalDecision(requestId, approved, approverName)`. `PendingApproval` interface exported from `api.ts`.
 
 ## Key Design Decisions
 

--- a/changelog/changelog_2026-04-13-2.md
+++ b/changelog/changelog_2026-04-13-2.md
@@ -1,0 +1,56 @@
+# Changelog — 2026-04-13 (session 2)
+
+## Summary
+Introduced a Dashboard as the new default landing screen for the React UI, replacing the empty-state rule library view. The sidebar was redesigned from a fixed desktop panel into a unified glassmorphism burger-menu overlay that works identically across all screen sizes.
+
+## Changes
+
+### Dashboard screen (new — `ui/src/components/Dashboard.tsx`)
+- Default view on app load (replaces the old empty "library" state).
+- Service health badges for Rule Engine and Decision Center with real-time status indicators and 3 s timeout probes.
+- Four stat cards: Rule Groups, Total Rules (with active count sublabel), Pending Approvals (amber-highlighted when non-zero), Decisions Today.
+- Decision Outcome breakdown section with animated progress bars (Approved / Rejected / Awaiting).
+- Pending Approvals panel with inline Approve / Reject buttons; optimistic removal from list on action.
+- Recent Decisions table (desktop) / card list (mobile, hidden on sm+) — last 10 entries, sorted by timestamp, click-through to Decision Log.
+- Auto-refresh every 30 seconds via `setInterval`; manual Refresh button in header.
+- All data fetched in parallel via `Promise.allSettled` — individual failures degrade gracefully without blocking other sections.
+
+### Sidebar redesign (`ui/src/components/Sidebar.tsx`)
+- Replaced fixed desktop sidebar (`lg:block lg:w-64`) with a glassmorphism slide-over overlay (`bg-white/85 backdrop-blur-xl`).
+- New props: `isOpen`, `onClose`, `activeView`, `onOpenDashboard`.
+- Smooth CSS transition (`translate-x-0` / `-translate-x-full`); backdrop overlay closes on click-outside.
+- Dashboard nav item added at the top of the nav list; active view is highlighted.
+- Removed legacy two-path (desktop/mobile) rendering — single component path now.
+
+### App shell (`ui/src/App.tsx`)
+- Added persistent top header bar (`h-14`) with hamburger/X toggle and breadcrumb navigation (`Unreal Objects > View > Group`).
+- Removed old `showGroupPanel` state; replaced with `sidebarOpen`.
+- Default `workspaceView` changed from `'library'` to `'dashboard'`.
+- Auto-select of first group on load removed (users arrive at Dashboard and choose from there).
+- Group selection no longer resets view to `'library'` if no group is selected.
+- `EmptyState` component simplified: checklist cards replaced with a "Back to Dashboard" link and a single "Configure LLM Provider" button (only shown when not yet configured).
+- Minor formatting/Tailwind class ordering cleanup (no functional change).
+
+### API layer (`ui/src/api.ts`)
+- Added `PendingApproval` interface.
+- Added `fetchRuleEngineHealth()` — `GET /v1/health` on Rule Engine with 3 s `AbortSignal.timeout`.
+- Added `fetchDecisionCenterHealth()` — `GET /v1/health` on Decision Center with 3 s `AbortSignal.timeout`. Both return `boolean`.
+- Added `fetchPendingApprovals()` — `GET /v1/pending` on Decision Center.
+- Added `submitApprovalDecision(requestId, approved, approverName)` — `POST /v1/decide/{id}/approve`.
+
+## Files Modified
+- `ui/src/components/Dashboard.tsx` — new file (Dashboard screen)
+- `ui/src/components/Sidebar.tsx` — glassmorphism overlay redesign
+- `ui/src/App.tsx` — persistent header, sidebar integration, default view change
+- `ui/src/api.ts` — four new Dashboard API functions + `PendingApproval` interface
+
+## Code Quality Notes
+- ESLint: **0 errors, 2 warnings** — both pre-existing `react-hooks/exhaustive-deps` warnings in `AgentAdminPanel.tsx`; no new issues introduced.
+- Python tests: **310 passed, 0 errors, 0 failures** (unchanged — no backend changes).
+- No TODO / FIXME / debug statements left in changed files.
+- No commented-out code blocks.
+
+## Open Items / Carry-over
+- `fetchPendingApprovals` depends on `GET /v1/pending` existing on the Decision Center; verify this endpoint is implemented and returns the expected `PendingApproval[]` shape.
+- `submitApprovalDecision` POSTs to `/v1/decide/{id}/approve` — confirm the Decision Center route signature matches (`approved`, `approver_name` body fields).
+- The two pre-existing `react-hooks/exhaustive-deps` warnings in `AgentAdminPanel.tsx` remain unaddressed.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,17 +6,28 @@ import { TestConsole } from './components/TestConsole';
 import { AgentAdminPanel } from './components/AgentAdminPanel';
 import { SchemaWorkshop } from './components/SchemaWorkshop';
 import { DecisionLog } from './components/DecisionLog';
+import { Dashboard } from './components/Dashboard';
 import { fetchGroups, createGroup, deleteGroup, checkLLMConnection } from './api';
-import { Bot, Settings, X, Save, Plus, PanelLeftOpen } from 'lucide-react';
+import { Bot, ChevronRight, Menu, Save, Settings, X } from 'lucide-react';
 import type { DatapointDefinition, LlmConfig, Rule, RuleGroup } from './types';
 
-type WorkspaceView = 'library' | 'builder' | 'agent-admin' | 'schema-workshop' | 'decision-log';
+type WorkspaceView = 'dashboard' | 'library' | 'builder' | 'agent-admin' | 'schema-workshop' | 'decision-log';
+
+const VIEW_LABELS: Record<WorkspaceView, string> = {
+  dashboard: 'Dashboard',
+  library: 'Rule Library',
+  builder: 'Rule Builder',
+  'agent-admin': 'Agent Admin',
+  'schema-workshop': 'Schema Workshop',
+  'decision-log': 'Decision Log',
+};
 
 function App() {
   const [groups, setGroups] = useState<RuleGroup[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // LLM Config — seeded from sessionStorage so values survive page refresh
   const [provider, setProvider] = useState(() => sessionStorage.getItem('llm_provider') || 'openai');
@@ -37,10 +48,9 @@ function App() {
   const [selectedRule, setSelectedRule] = useState<Rule | null>(null);
   const [selectedRuleToken, setSelectedRuleToken] = useState(0);
   const [rulePanelRefreshKey, setRulePanelRefreshKey] = useState(0);
-  const [showGroupPanel, setShowGroupPanel] = useState(false);
   const [systemNotice, setSystemNotice] = useState<string | null>(null);
   const [systemNoticeToken, setSystemNoticeToken] = useState(0);
-  const [workspaceView, setWorkspaceView] = useState<WorkspaceView>('library');
+  const [workspaceView, setWorkspaceView] = useState<WorkspaceView>('dashboard');
   const providerSelectRef = useRef<HTMLSelectElement>(null);
 
   useEffect(() => {
@@ -62,7 +72,7 @@ function App() {
       const data = await fetchGroups();
       setGroups(data);
       if (data.length > 0 && !selectedGroupId) {
-        setSelectedGroupId(data[0].id);
+        // Don't auto-select; let user pick from dashboard/sidebar
       }
     } catch (err) {
       console.error('Failed to load groups:', err);
@@ -76,10 +86,11 @@ function App() {
   useEffect(() => {
     setSelectedRule(null);
     setSelectedRuleToken(0);
-    setShowGroupPanel(false);
     setSystemNotice(null);
     setSystemNoticeToken(0);
-    setWorkspaceView('library');
+    if (selectedGroupId) {
+      setWorkspaceView('library');
+    }
   }, [selectedGroupId]);
 
   const handleCreateGroup = async (name: string, description: string) => {
@@ -108,15 +119,15 @@ function App() {
   };
 
   const handleRuleUpdated = (rule: Rule) => {
-    setSelectedRule((current) => current?.id === rule.id ? rule : current);
+    setSelectedRule((current) => (current?.id === rule.id ? rule : current));
   };
 
   const handleRuleStatusChanged = (rule: Rule) => {
-    setSelectedRule((current) => current?.id === rule.id ? rule : current);
+    setSelectedRule((current) => (current?.id === rule.id ? rule : current));
     setSystemNotice(
       rule.active
         ? `Rule '${rule.name}' reactivated. It is live in evaluation again.`
-        : `Rule '${rule.name}' deactivated. It remains documented but will be skipped during evaluation.`
+        : `Rule '${rule.name}' deactivated. It remains documented but will be skipped during evaluation.`,
     );
     setSystemNoticeToken(Date.now());
   };
@@ -126,9 +137,7 @@ function App() {
     setGroups((prev) => {
       const nextGroups = prev.filter((item) => item.id !== group.id);
       setSelectedGroupId((current) => {
-        if (current !== group.id) {
-          return current;
-        }
+        if (current !== group.id) return current;
         return nextGroups[0]?.id ?? null;
       });
       return nextGroups;
@@ -139,7 +148,7 @@ function App() {
     setTestDatapointDefs([]);
     setSystemNotice(`Rule group '${group.name}' destroyed.`);
     setSystemNoticeToken(Date.now());
-    setWorkspaceView('library');
+    setWorkspaceView('dashboard');
   };
 
   const handleSaveLlmConfig = async () => {
@@ -151,7 +160,7 @@ function App() {
       sessionStorage.setItem('llm_model', model);
       sessionStorage.setItem('llm_api_key', apiKey);
       setLlmConfig({ provider, model, api_key: apiKey });
-        setShowSettings(false);
+      setShowSettings(false);
     } catch (err: unknown) {
       setLlmError(err instanceof Error ? err.message : 'Connection failed. Please check your API key.');
     } finally {
@@ -159,88 +168,90 @@ function App() {
     }
   };
 
+  const selectedGroup = groups.find((g) => g.id === selectedGroupId);
+
   return (
-    <div className="flex h-screen bg-white transition-colors dark:bg-gray-900 overflow-hidden font-sans">
-      <div className="hidden lg:block lg:w-64 lg:flex-shrink-0">
-        <Sidebar
-          groups={groups}
-          selectedGroupId={selectedGroupId}
-          onSelectGroup={(id) => {
-            setSelectedGroupId(id);
-            setWorkspaceView('library');
-          }}
-          onOpenAgentAdmin={() => setWorkspaceView('agent-admin')}
-          onOpenSchemaWorkshop={() => setWorkspaceView('schema-workshop')}
-          onOpenDecisionLog={() => setWorkspaceView('decision-log')}
-          onCreateGroup={handleCreateGroup}
-          onDeleteGroup={handleDeleteGroup}
-          isDarkMode={isDarkMode}
-          toggleDarkMode={() => setIsDarkMode(!isDarkMode)}
-          onOpenSettings={() => setShowSettings(true)}
-          llmConfigured={!!llmConfig}
-        />
-      </div>
+    <div className="flex h-screen flex-col bg-white font-sans transition-colors dark:bg-gray-900 overflow-hidden">
 
-      {showGroupPanel && (
-        <div className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm lg:hidden" onClick={() => setShowGroupPanel(false)}>
-          <div className="panel-enter-left h-full w-80 max-w-[85vw] shadow-2xl" onClick={(e) => e.stopPropagation()}>
-            <Sidebar
-              groups={groups}
-              selectedGroupId={selectedGroupId}
-              onSelectGroup={(id) => {
-                setSelectedGroupId(id);
-                setWorkspaceView('library');
-                setShowGroupPanel(false);
-              }}
-              onOpenAgentAdmin={() => {
-                setWorkspaceView('agent-admin');
-                setShowGroupPanel(false);
-              }}
-              onOpenSchemaWorkshop={() => {
-                setWorkspaceView('schema-workshop');
-                setShowGroupPanel(false);
-              }}
-              onOpenDecisionLog={() => {
-                setWorkspaceView('decision-log');
-                setShowGroupPanel(false);
-              }}
-              onCreateGroup={handleCreateGroup}
-              onDeleteGroup={handleDeleteGroup}
-              isDarkMode={isDarkMode}
-              toggleDarkMode={() => setIsDarkMode(!isDarkMode)}
-              onOpenSettings={() => {
-                setShowSettings(true);
-                setShowGroupPanel(false);
-              }}
-              llmConfigured={!!llmConfig}
-            />
-          </div>
-        </div>
-      )}
+      {/* ── Top header bar ───────────────────────────────────────────── */}
+      <header className="flex h-14 flex-shrink-0 items-center gap-3 border-b border-gray-200 bg-white px-4 dark:border-gray-800 dark:bg-gray-900">
+        <button
+          onClick={() => setSidebarOpen((v) => !v)}
+          className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-gray-200 bg-white/90 shadow-sm transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
+          aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+        >
+          {sidebarOpen ? <X size={18} /> : <Menu size={18} />}
+        </button>
 
-      <main className="flex min-w-0 flex-1 bg-white transition-colors dark:bg-gray-900">
-        <div className="flex min-w-0 flex-1 flex-col">
-          {selectedGroupId && (
-            <div className="border-b border-gray-200 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-900 lg:hidden">
-              <div className="flex items-center justify-between gap-2">
-                <button
-                  onClick={() => setShowGroupPanel(true)}
-                  className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
-                  aria-label="Open groups"
-                >
-                  <PanelLeftOpen size={16} />
-                  Groups
-                </button>
-                <div className="min-w-0 flex-1 text-center text-sm font-semibold text-gray-800 dark:text-gray-100">
-                  <span className="truncate">{groups.find((group) => group.id === selectedGroupId)?.name ?? 'Rule Group'}</span>
-                </div>
-                <div className="w-[76px]" aria-hidden="true" />
-              </div>
-            </div>
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm">
+          <span className="font-semibold text-gray-900 dark:text-gray-100">Unreal Objects</span>
+          {workspaceView !== 'dashboard' && (
+            <>
+              <ChevronRight size={14} className="flex-shrink-0 text-gray-400" />
+              <span className="truncate text-gray-500 dark:text-gray-400">
+                {VIEW_LABELS[workspaceView]}
+              </span>
+            </>
           )}
+          {selectedGroup && (workspaceView === 'library' || workspaceView === 'builder') && (
+            <>
+              <ChevronRight size={14} className="flex-shrink-0 text-gray-400" />
+              <span className="truncate font-medium text-gray-700 dark:text-gray-300">
+                {selectedGroup.name}
+              </span>
+            </>
+          )}
+        </div>
+      </header>
 
+      {/* ── Glassmorphism sidebar overlay ────────────────────────────── */}
+      <Sidebar
+        isOpen={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        activeView={workspaceView}
+        onSelectGroup={(id) => {
+          setSelectedGroupId(id);
+          setWorkspaceView('library');
+          setSidebarOpen(false);
+        }}
+        onOpenDashboard={() => {
+          setWorkspaceView('dashboard');
+          setSidebarOpen(false);
+        }}
+        onOpenAgentAdmin={() => {
+          setWorkspaceView('agent-admin');
+          setSidebarOpen(false);
+        }}
+        onOpenSchemaWorkshop={() => {
+          setWorkspaceView('schema-workshop');
+          setSidebarOpen(false);
+        }}
+        onOpenDecisionLog={() => {
+          setWorkspaceView('decision-log');
+          setSidebarOpen(false);
+        }}
+        onCreateGroup={handleCreateGroup}
+        onDeleteGroup={handleDeleteGroup}
+        isDarkMode={isDarkMode}
+        toggleDarkMode={() => setIsDarkMode(!isDarkMode)}
+        onOpenSettings={() => {
+          setShowSettings(true);
+          setSidebarOpen(false);
+        }}
+        llmConfigured={!!llmConfig}
+      />
+
+      {/* ── Main content area ─────────────────────────────────────────── */}
+      <main className="flex min-h-0 flex-1 bg-white transition-colors dark:bg-gray-900">
+        <div className="flex min-w-0 flex-1 flex-col">
           <div className="min-h-0 flex-1">
-            {workspaceView === 'agent-admin' ? (
+            {workspaceView === 'dashboard' ? (
+              <Dashboard
+                onNavigateToDecisionLog={() => setWorkspaceView('decision-log')}
+              />
+            ) : workspaceView === 'agent-admin' ? (
               <div className="h-full overflow-y-auto p-6">
                 <div className="mx-auto max-w-6xl">
                   <AgentAdminPanel />
@@ -283,7 +294,10 @@ function App() {
                   systemNotice={systemNotice}
                   systemNoticeToken={systemNoticeToken}
                   onRuleCreated={handleRuleSaved}
-                  onStartTest={(rule, defs) => { setRuleToTest(rule); setTestDatapointDefs(defs); }}
+                  onStartTest={(rule, defs) => {
+                    setRuleToTest(rule);
+                    setTestDatapointDefs(defs);
+                  }}
                   onStopEditing={() => {
                     setSelectedRule(null);
                     setSelectedRuleToken(0);
@@ -296,6 +310,7 @@ function App() {
                 hasGroups={groups.length > 0}
                 llmConfigured={!!llmConfig}
                 onOpenSettings={() => setShowSettings(true)}
+                onOpenDashboard={() => setWorkspaceView('dashboard')}
               />
             )}
           </div>
@@ -313,29 +328,31 @@ function App() {
 
       {/* Settings Modal */}
       {showSettings && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="bg-white dark:bg-gray-800 rounded-xl max-w-2xl w-full max-h-[90vh] shadow-2xl overflow-hidden">
-            <div className="p-4 border-b border-gray-200 dark:border-gray-700 font-semibold flex items-center justify-between text-gray-800 dark:text-gray-200">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-800">
+            <div className="flex items-center justify-between border-b border-gray-200 p-4 font-semibold text-gray-800 dark:border-gray-700 dark:text-gray-200">
               <div className="flex items-center gap-2">
                 <Settings size={18} />
                 LLM Provider Settings
               </div>
               <button
                 onClick={() => setShowSettings(false)}
-                className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                className="rounded p-1 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
               >
                 <X size={18} />
               </button>
             </div>
-            <div className="max-h-[calc(90vh-128px)] overflow-y-auto p-5 space-y-6">
+            <div className="max-h-[calc(90vh-128px)] space-y-6 overflow-y-auto p-5">
               <section className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Provider</label>
+                  <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Provider
+                  </label>
                   <select
                     ref={providerSelectRef}
                     value={provider}
                     onChange={(e) => setProvider(e.target.value)}
-                    className="w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+                    className="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                   >
                     <option value="openai">OpenAI</option>
                     <option value="anthropic">Anthropic</option>
@@ -343,46 +360,48 @@ function App() {
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Model Name</label>
+                  <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Model Name
+                  </label>
                   <input
                     type="text"
                     value={model}
                     onChange={(e) => setModel(e.target.value)}
                     placeholder="e.g. gpt-5.2-2025-12-11, claude-sonnet-4-6"
-                    className="w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400"
+                    className="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">API Key</label>
+                  <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    API Key
+                  </label>
                   <input
                     type="password"
                     value={apiKey}
                     onChange={(e) => setApiKey(e.target.value)}
                     placeholder="sk-..."
-                    className="w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400"
+                    className="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
                   />
                 </div>
                 {llmError && (
-                  <div className="text-red-600 dark:text-red-400 text-sm font-medium">
-                    {llmError}
-                  </div>
+                  <div className="text-sm font-medium text-red-600 dark:text-red-400">{llmError}</div>
                 )}
               </section>
             </div>
-            <div className="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 flex justify-end gap-2">
+            <div className="flex justify-end gap-2 border-t border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/50">
               <button
                 onClick={() => setShowSettings(false)}
-                className="px-4 py-2 font-medium text-sm text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors"
+                className="px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSaveLlmConfig}
                 disabled={isTestingLlm || !apiKey}
-                className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium text-sm rounded-lg transition-colors disabled:opacity-50"
+                className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
               >
                 {isTestingLlm ? <Bot size={16} className="animate-spin" /> : <Save size={16} />}
-                {isTestingLlm ? 'Testing...' : 'Save & Connect'}
+                {isTestingLlm ? 'Testing…' : 'Save & Connect'}
               </button>
             </div>
           </div>
@@ -396,58 +415,41 @@ function EmptyState({
   hasGroups,
   llmConfigured,
   onOpenSettings,
+  onOpenDashboard,
 }: {
   hasGroups: boolean;
   llmConfigured: boolean;
   onOpenSettings: () => void;
+  onOpenDashboard: () => void;
 }) {
   return (
-    <div className="flex-1 flex items-center justify-center p-8">
-      <div className="text-center max-w-sm">
-        <div className="w-16 h-16 rounded-2xl bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center mx-auto mb-4">
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="max-w-sm text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 dark:bg-blue-900/20">
           <Bot size={32} className="text-blue-500 dark:text-blue-400" />
         </div>
-        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
+        <h2 className="mb-2 text-lg font-semibold text-gray-800 dark:text-gray-200">
           {hasGroups ? 'Select a Rule Group' : 'Get Started'}
         </h2>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+        <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
           {hasGroups
             ? 'Choose a rule group from the sidebar to view and create rules.'
             : 'Set up your LLM provider, then create your first rule group to begin.'}
         </p>
-
-        {!hasGroups && (
-          <div className="space-y-3 text-left">
-            <div
-              className={`flex items-start gap-3 p-3 rounded-xl border cursor-pointer transition-colors ${
-                !llmConfigured
-                  ? 'border-amber-200 dark:border-amber-800/50 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/30'
-                  : 'border-green-200 dark:border-green-800/50 bg-green-50 dark:bg-green-900/20'
-              }`}
-              onClick={!llmConfigured ? onOpenSettings : undefined}
+        <button
+          onClick={onOpenDashboard}
+          className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+        >
+          ← Back to Dashboard
+        </button>
+        {!hasGroups && !llmConfigured && (
+          <div className="mt-4">
+            <button
+              onClick={onOpenSettings}
+              className="inline-flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:border-amber-800/50 dark:bg-amber-900/20 dark:text-amber-300"
             >
-              <span className="text-lg mt-0.5">{llmConfigured ? '✅' : '⚙️'}</span>
-              <div>
-                <div className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                  Configure LLM Provider
-                </div>
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  {llmConfigured ? 'Connected and ready.' : 'Click to set your API key and model.'}
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3 p-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
-              <Plus size={18} className="text-gray-400 mt-0.5 flex-shrink-0" />
-              <div>
-                <div className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                  Create a Rule Group
-                </div>
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  Use the sidebar button to name and create your first group.
-                </div>
-              </div>
-            </div>
+              ⚙️ Configure LLM Provider
+            </button>
           </div>
         )}
       </div>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -348,7 +348,7 @@ export const revokeCredential = async (
 
 export interface PendingApproval {
   request_id: string;
-  request_description: string;
+  description: string;
   context: Record<string, unknown>;
   agent_id?: string | null;
   credential_id?: string | null;
@@ -394,7 +394,7 @@ export const submitApprovalDecision = async (
   const res = await fetch(`${DECISION_BASE}/decide/${encodeURIComponent(requestId)}/approve`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ approved, approver_name: approverName }),
+    body: JSON.stringify({ approved, approver: approverName }),
   });
   if (!res.ok) throw new Error('Failed to submit approval decision');
 };

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -343,3 +343,58 @@ export const revokeCredential = async (
   if (!res.ok) throw new Error('Failed to revoke credential');
   return res.json();
 };
+
+// ── Dashboard API ────────────────────────────────────────────────────────────
+
+export interface PendingApproval {
+  request_id: string;
+  request_description: string;
+  context: Record<string, unknown>;
+  agent_id?: string | null;
+  credential_id?: string | null;
+  user_id?: string | null;
+  effective_group_id?: string | null;
+}
+
+export const fetchRuleEngineHealth = async (): Promise<boolean> => {
+  try {
+    const res = await fetch(`${RULE_ENGINE_ORIGIN}/v1/health`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(3000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+export const fetchDecisionCenterHealth = async (): Promise<boolean> => {
+  try {
+    const res = await fetch(`${DECISION_CENTER_ORIGIN}/v1/health`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(3000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+export const fetchPendingApprovals = async (): Promise<PendingApproval[]> => {
+  const res = await fetch(`${DECISION_BASE}/pending`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to fetch pending approvals');
+  return res.json();
+};
+
+export const submitApprovalDecision = async (
+  requestId: string,
+  approved: boolean,
+  approverName: string,
+): Promise<void> => {
+  const res = await fetch(`${DECISION_BASE}/decide/${encodeURIComponent(requestId)}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ approved, approver_name: approverName }),
+  });
+  if (!res.ok) throw new Error('Failed to submit approval decision');
+};

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -1,0 +1,476 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Activity,
+  CheckCircle2,
+  Clock,
+  LayoutDashboard,
+  RefreshCw,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react';
+import {
+  fetchAtomicLogs,
+  fetchDecisionCenterHealth,
+  fetchGroups,
+  fetchPendingApprovals,
+  fetchRuleEngineHealth,
+  submitApprovalDecision,
+} from '../api';
+import type { AtomicLogEntry, DecisionState, RuleGroup } from '../types';
+import type { PendingApproval } from '../api';
+
+interface DashboardProps {
+  onNavigateToDecisionLog: () => void;
+}
+
+function timeAgo(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function isToday(ts: string): boolean {
+  const d = new Date(ts);
+  const now = new Date();
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
+}
+
+function DecisionBadge({ decision }: { decision: DecisionState }) {
+  if (decision === 'APPROVED')
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+        ✓ Approved
+      </span>
+    );
+  if (decision === 'REJECTED')
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400">
+        ✗ Rejected
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+      ⏳ Awaiting
+    </span>
+  );
+}
+
+function ServiceBadge({ label, online }: { label: string; online: boolean | null }) {
+  const isLoading = online === null;
+  const isOnline = online === true;
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <span
+        className={`h-2 w-2 rounded-full ${
+          isLoading
+            ? 'animate-pulse bg-gray-300'
+            : isOnline
+              ? 'bg-green-500'
+              : 'bg-red-500'
+        }`}
+      />
+      <span className="text-xs font-medium text-gray-600 dark:text-gray-300">{label}</span>
+      <span
+        className={`text-xs ${
+          isLoading
+            ? 'text-gray-400'
+            : isOnline
+              ? 'text-green-600 dark:text-green-400'
+              : 'text-red-600 dark:text-red-400'
+        }`}
+      >
+        {isLoading ? '…' : isOnline ? 'Online' : 'Offline'}
+      </span>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  sublabel,
+  icon,
+  iconBg,
+  highlight = false,
+}: {
+  label: string;
+  value: number;
+  sublabel?: string;
+  icon: React.ReactNode;
+  iconBg: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-xl border bg-white p-4 dark:bg-gray-900 ${
+        highlight
+          ? 'border-amber-200 dark:border-amber-800/50'
+          : 'border-gray-200 dark:border-gray-800'
+      }`}
+    >
+      <div
+        className={`mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg ${iconBg}`}
+      >
+        {icon}
+      </div>
+      <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value}</div>
+      <div className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">{label}</div>
+      {sublabel && <div className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">{sublabel}</div>}
+    </div>
+  );
+}
+
+function OutcomeRow({
+  label,
+  count,
+  pct,
+  barColor,
+  icon,
+}: {
+  label: string;
+  count: number;
+  pct: number;
+  barColor: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center gap-2">
+          {icon}
+          <span className="text-gray-700 dark:text-gray-300">{label}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-gray-900 dark:text-gray-100">{count}</span>
+          <span className="w-8 text-right text-xs text-gray-400">{pct}%</span>
+        </div>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        <div
+          className={`h-full rounded-full ${barColor} transition-all duration-700`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const Dashboard: React.FC<DashboardProps> = ({ onNavigateToDecisionLog }) => {
+  const [ruleEngineOnline, setRuleEngineOnline] = useState<boolean | null>(null);
+  const [decisionCenterOnline, setDecisionCenterOnline] = useState<boolean | null>(null);
+  const [groups, setGroups] = useState<RuleGroup[]>([]);
+  const [logs, setLogs] = useState<AtomicLogEntry[]>([]);
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
+  const [approvingId, setApprovingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const [reHealth, dcHealth, groupsData, logsData, pendingData] = await Promise.allSettled([
+      fetchRuleEngineHealth(),
+      fetchDecisionCenterHealth(),
+      fetchGroups(),
+      fetchAtomicLogs(),
+      fetchPendingApprovals(),
+    ]);
+
+    setRuleEngineOnline(reHealth.status === 'fulfilled' ? reHealth.value : false);
+    setDecisionCenterOnline(dcHealth.status === 'fulfilled' ? dcHealth.value : false);
+    if (groupsData.status === 'fulfilled') setGroups(groupsData.value);
+    if (logsData.status === 'fulfilled') setLogs(logsData.value);
+    setPending(pendingData.status === 'fulfilled' ? pendingData.value : []);
+
+    setLastRefresh(new Date());
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, 30_000);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  const handleApprove = async (requestId: string, approved: boolean) => {
+    setApprovingId(requestId);
+    try {
+      await submitApprovalDecision(requestId, approved, 'Dashboard');
+      setPending((prev) => prev.filter((p) => p.request_id !== requestId));
+    } catch {
+      // next refresh will correct state
+    } finally {
+      setApprovingId(null);
+    }
+  };
+
+  const totalRules = groups.reduce((sum, g) => sum + g.rules.length, 0);
+  const activeRules = groups.reduce((sum, g) => sum + g.rules.filter((r) => r.active).length, 0);
+  const todayCount = logs.filter((l) => isToday(l.timestamp)).length;
+
+  const approvedCount = logs.filter((l) => l.decision === 'APPROVED').length;
+  const rejectedCount = logs.filter((l) => l.decision === 'REJECTED').length;
+  const awaitingCount = logs.filter((l) => l.decision === 'APPROVAL_REQUIRED').length;
+  const total = approvedCount + rejectedCount + awaitingCount || 1;
+
+  const recentLogs = [...logs]
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+    .slice(0, 10);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <RefreshCw size={24} className="animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 sm:px-6">
+
+        {/* Header row */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <LayoutDashboard size={20} className="text-blue-500" />
+            <h1 className="text-lg font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
+          </div>
+          <button
+            onClick={load}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+          >
+            <RefreshCw size={13} />
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
+        </div>
+
+        {/* Service health */}
+        <div className="flex flex-wrap items-center gap-3">
+          <ServiceBadge label="Rule Engine" online={ruleEngineOnline} />
+          <ServiceBadge label="Decision Center" online={decisionCenterOnline} />
+          <span className="ml-auto text-xs text-gray-400">
+            Updated {lastRefresh.toLocaleTimeString()}
+          </span>
+        </div>
+
+        {/* Stat cards */}
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+          <StatCard
+            label="Rule Groups"
+            value={groups.length}
+            icon={<ShieldCheck size={18} className="text-blue-500" />}
+            iconBg="bg-blue-50 dark:bg-blue-950/30"
+          />
+          <StatCard
+            label="Total Rules"
+            value={totalRules}
+            sublabel={`${activeRules} active`}
+            icon={<Activity size={18} className="text-indigo-500" />}
+            iconBg="bg-indigo-50 dark:bg-indigo-950/30"
+          />
+          <StatCard
+            label="Pending"
+            value={pending.length}
+            icon={
+              <Clock
+                size={18}
+                className={pending.length > 0 ? 'text-amber-500' : 'text-gray-400'}
+              />
+            }
+            iconBg={
+              pending.length > 0
+                ? 'bg-amber-50 dark:bg-amber-950/30'
+                : 'bg-gray-50 dark:bg-gray-800/40'
+            }
+            highlight={pending.length > 0}
+          />
+          <StatCard
+            label="Decisions Today"
+            value={todayCount}
+            icon={<CheckCircle2 size={18} className="text-green-500" />}
+            iconBg="bg-green-50 dark:bg-green-950/30"
+          />
+        </div>
+
+        {/* Middle row: outcomes + pending approvals */}
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+
+          {/* Decision outcomes */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
+            <h2 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Decision Outcomes
+            </h2>
+            {logs.length === 0 ? (
+              <p className="py-4 text-center text-sm text-gray-400">No decisions recorded yet.</p>
+            ) : (
+              <div className="space-y-4">
+                <OutcomeRow
+                  label="Approved"
+                  count={approvedCount}
+                  pct={Math.round((approvedCount / total) * 100)}
+                  barColor="bg-green-500"
+                  icon={<CheckCircle2 size={15} className="text-green-500" />}
+                />
+                <OutcomeRow
+                  label="Rejected"
+                  count={rejectedCount}
+                  pct={Math.round((rejectedCount / total) * 100)}
+                  barColor="bg-red-500"
+                  icon={<XCircle size={15} className="text-red-500" />}
+                />
+                <OutcomeRow
+                  label="Awaiting"
+                  count={awaitingCount}
+                  pct={Math.round((awaitingCount / total) * 100)}
+                  barColor="bg-amber-400"
+                  icon={<Clock size={15} className="text-amber-500" />}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Pending approvals */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
+            <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Pending Approvals
+              {pending.length > 0 && (
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-amber-500 text-xs font-bold text-white">
+                  {pending.length}
+                </span>
+              )}
+            </h2>
+            {pending.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-6 text-center">
+                <CheckCircle2 size={30} className="mb-2 text-green-400" />
+                <p className="text-sm text-gray-400">All clear — no pending approvals</p>
+              </div>
+            ) : (
+              <div className="max-h-52 space-y-2 overflow-y-auto">
+                {pending.map((p) => (
+                  <div
+                    key={p.request_id}
+                    className="flex items-start gap-2 rounded-lg border border-amber-100 bg-amber-50/60 p-3 dark:border-amber-900/30 dark:bg-amber-950/10"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-gray-800 dark:text-gray-200">
+                        {p.request_description}
+                      </div>
+                      {p.agent_id && (
+                        <div className="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">
+                          Agent: {p.agent_id}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex flex-shrink-0 gap-1">
+                      <button
+                        disabled={approvingId === p.request_id}
+                        onClick={() => handleApprove(p.request_id, true)}
+                        className="rounded-md bg-green-100 px-2 py-1 text-xs font-semibold text-green-700 transition-colors hover:bg-green-200 disabled:opacity-50 dark:bg-green-900/30 dark:text-green-400 dark:hover:bg-green-900/50"
+                        title="Approve"
+                      >
+                        ✓
+                      </button>
+                      <button
+                        disabled={approvingId === p.request_id}
+                        onClick={() => handleApprove(p.request_id, false)}
+                        className="rounded-md bg-red-100 px-2 py-1 text-xs font-semibold text-red-700 transition-colors hover:bg-red-200 disabled:opacity-50 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+                        title="Reject"
+                      >
+                        ✗
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Recent decisions */}
+        <div className="rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+          <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Recent Decisions
+            </h2>
+            <button
+              onClick={onNavigateToDecisionLog}
+              className="text-xs text-blue-500 transition-colors hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              View all →
+            </button>
+          </div>
+
+          {recentLogs.length === 0 ? (
+            <div className="px-5 py-8 text-center text-sm text-gray-400">
+              No decisions recorded yet.
+            </div>
+          ) : (
+            <>
+              {/* Desktop table */}
+              <div className="hidden sm:block">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100 text-xs text-gray-400 dark:border-gray-800">
+                      <th className="px-5 py-3 text-left font-medium">Time</th>
+                      <th className="px-5 py-3 text-left font-medium">Description</th>
+                      <th className="px-5 py-3 text-left font-medium">Agent</th>
+                      <th className="px-5 py-3 text-left font-medium">Decision</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-50 dark:divide-gray-800/50">
+                    {recentLogs.map((log) => (
+                      <tr
+                        key={log.request_id}
+                        className="cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/30"
+                        onClick={onNavigateToDecisionLog}
+                      >
+                        <td className="whitespace-nowrap px-5 py-3 text-xs text-gray-400">
+                          {timeAgo(log.timestamp)}
+                        </td>
+                        <td className="max-w-xs truncate px-5 py-3 text-gray-700 dark:text-gray-300">
+                          {log.request_description}
+                        </td>
+                        <td className="px-5 py-3 text-xs text-gray-500 dark:text-gray-400">
+                          {log.agent_id ?? '—'}
+                        </td>
+                        <td className="px-5 py-3">
+                          <DecisionBadge decision={log.decision} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Mobile card list */}
+              <div className="space-y-2 p-4 sm:hidden">
+                {recentLogs.map((log) => (
+                  <div
+                    key={log.request_id}
+                    className="flex cursor-pointer items-center justify-between gap-2 rounded-lg border border-gray-100 p-3 transition-colors hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800/30"
+                    onClick={onNavigateToDecisionLog}
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm text-gray-800 dark:text-gray-200">
+                        {log.request_description}
+                      </div>
+                      <div className="mt-0.5 text-xs text-gray-400">{timeAgo(log.timestamp)}</div>
+                    </div>
+                    <DecisionBadge decision={log.decision} />
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -360,7 +360,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onNavigateToDecisionLog })
                   >
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-medium text-gray-800 dark:text-gray-200">
-                        {p.request_description}
+                        {p.description}
                       </div>
                       {p.agent_id && (
                         <div className="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -153,7 +153,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
         className={`fixed bottom-0 left-0 top-14 z-50 flex w-full flex-col border-r border-white/20 bg-white/85 shadow-2xl backdrop-blur-xl transition-transform duration-300 ease-out dark:border-white/10 dark:bg-gray-950/88 sm:w-80 ${
           isOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
-        aria-modal="true"
+        aria-modal={isOpen}
+        aria-hidden={!isOpen}
+        inert={!isOpen ? true : undefined}
         role="dialog"
       >
         {/* New Group Button or Inline Form */}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,8 +1,24 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Plus, Settings, ListTodo, Sun, Moon, Check, X, AlertTriangle, ShieldCheck, Layers, ScrollText, Trash2 } from 'lucide-react';
+import {
+  Plus,
+  Settings,
+  ListTodo,
+  Sun,
+  Moon,
+  Check,
+  X,
+  AlertTriangle,
+  ShieldCheck,
+  Layers,
+  ScrollText,
+  Trash2,
+  LayoutDashboard,
+} from 'lucide-react';
 import type { RuleGroup } from '../types';
 
 interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
   groups: RuleGroup[];
   selectedGroupId: string | null;
   onSelectGroup: (id: string) => void;
@@ -14,11 +30,14 @@ interface SidebarProps {
   onOpenAgentAdmin: () => void;
   onOpenSchemaWorkshop?: () => void;
   onOpenDecisionLog: () => void;
+  onOpenDashboard: () => void;
   llmConfigured: boolean;
-  className?: string;
+  activeView?: string;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
+  isOpen,
+  onClose,
   groups,
   selectedGroupId,
   onSelectGroup,
@@ -30,8 +49,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onOpenAgentAdmin,
   onOpenSchemaWorkshop,
   onOpenDecisionLog,
+  onOpenDashboard,
   llmConfigured,
-  className = '',
+  activeView,
 }) => {
   const [showForm, setShowForm] = useState(false);
   const [name, setName] = useState('');
@@ -39,23 +59,31 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [groupPendingDelete, setGroupPendingDelete] = useState<RuleGroup | null>(null);
   const [deleteConfirmation, setDeleteConfirmation] = useState('');
-  const [adminToken, setAdminToken] = useState(() => sessionStorage.getItem('rule_engine_admin_token') || '');
+  const [adminToken, setAdminToken] = useState(
+    () => sessionStorage.getItem('rule_engine_admin_token') || '',
+  );
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const deleteConfirmInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (showForm) {
-      nameInputRef.current?.focus();
-    }
+    if (showForm) nameInputRef.current?.focus();
   }, [showForm]);
 
   useEffect(() => {
-    if (groupPendingDelete) {
-      deleteConfirmInputRef.current?.focus();
-    }
+    if (groupPendingDelete) deleteConfirmInputRef.current?.focus();
   }, [groupPendingDelete]);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
 
   const handleCreate = async () => {
     if (!name.trim() || isSubmitting) return;
@@ -102,209 +130,239 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   };
 
+  const footerBtnBase =
+    'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors text-sm font-medium';
+  const footerBtnIdle =
+    'text-gray-600 dark:text-gray-400 hover:bg-white/60 dark:hover:bg-white/5';
+  const footerBtnActive =
+    'bg-blue-50/80 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300';
+
   return (
-    <div className={`h-full w-full bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex flex-col transition-colors duration-200 ${className}`}>
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/30 backdrop-blur-sm transition-opacity duration-300 ${
+          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
 
-      {/* New Group Button or Inline Form */}
-      <div className="sticky top-0 z-10 p-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur">
-        {!showForm ? (
-          <button
-            onClick={() => setShowForm(true)}
-            className="w-full flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
-          >
-            <Plus size={18} />
-            New Rule Group
-          </button>
-        ) : (
-          <div className="space-y-2">
-            <input
-              ref={nameInputRef}
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleCreate();
-                if (e.key === 'Escape') handleCancel();
-              }}
-              placeholder="Group name *"
-              className="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
-            />
-            <input
-              type="text"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleCreate();
-                if (e.key === 'Escape') handleCancel();
-              }}
-              placeholder="Description (optional)"
-              className="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
-            />
-            <div className="flex gap-2">
-              <button
-                onClick={handleCreate}
-                disabled={!name.trim() || isSubmitting}
-                className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
-              >
-                <Check size={14} />
-                {isSubmitting ? 'Creating...' : 'Create'}
-              </button>
-              <button
-                onClick={handleCancel}
-                className="p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors"
-              >
-                <X size={16} />
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Groups List */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-1">
-        {groups.length > 0 && (
-          <div className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider pb-2">
-            Rule Groups
-          </div>
-        )}
-
-        {groups.map((group) => (
-          <div key={group.id} className="space-y-2">
-            <div
-              className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
-                selectedGroupId === group.id
-                  ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
-                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800/50'
-              }`}
+      {/* Panel */}
+      <div
+        className={`fixed bottom-0 left-0 top-14 z-50 flex w-full flex-col border-r border-white/20 bg-white/85 shadow-2xl backdrop-blur-xl transition-transform duration-300 ease-out dark:border-white/10 dark:bg-gray-950/88 sm:w-80 ${
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+        aria-modal="true"
+        role="dialog"
+      >
+        {/* New Group Button or Inline Form */}
+        <div className="sticky top-0 z-10 border-b border-white/30 bg-white/60 p-4 backdrop-blur-sm dark:border-white/10 dark:bg-gray-950/60">
+          {!showForm ? (
+            <button
+              onClick={() => setShowForm(true)}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700"
             >
-              <button
-                onClick={() => onSelectGroup(group.id)}
-                className="flex min-w-0 flex-1 items-center gap-3 text-left"
-              >
-                <ListTodo size={16} className="flex-shrink-0" />
-                <div className="flex-1 overflow-hidden">
-                  <div className="truncate text-sm font-medium">{group.name}</div>
-                  {group.description && (
-                    <div className="text-xs truncate opacity-60">{group.description}</div>
-                  )}
-                </div>
-              </button>
-              <button
-                type="button"
-                aria-label="Destroy rule group"
-                onClick={() => openDeleteFlow(group)}
-                className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-300"
-              >
-                <Trash2 size={15} />
-              </button>
-            </div>
-
-            {groupPendingDelete?.id === group.id && (
-              <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm dark:border-red-900/40 dark:bg-red-950/20">
-                <div className="font-semibold text-red-800 dark:text-red-200">Destroy rule group</div>
-                <p className="mt-1 text-xs text-red-700 dark:text-red-300">
-                  This permanently removes the group and every rule inside it.
-                </p>
-                <p className="mt-2 text-xs text-red-700 dark:text-red-300">
-                  Type <span className="font-semibold">{group.name}</span> to confirm.
-                </p>
-                <input
-                  ref={deleteConfirmInputRef}
-                  type="text"
-                  value={deleteConfirmation}
-                  onChange={(e) => setDeleteConfirmation(e.target.value)}
-                  placeholder="Exact group name"
-                  className="mt-3 w-full rounded-lg border border-red-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none focus:ring-2 focus:ring-red-500 dark:border-red-900/40 dark:bg-gray-900 dark:text-gray-100"
-                />
-                <input
-                  type="password"
-                  value={adminToken}
-                  onChange={(e) => setAdminToken(e.target.value)}
-                  placeholder="Admin token (only if server requires it)"
-                  className="mt-2 w-full rounded-lg border border-red-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none focus:ring-2 focus:ring-red-500 dark:border-red-900/40 dark:bg-gray-900 dark:text-gray-100"
-                />
-                {deleteError && (
-                  <div className="mt-2 text-xs font-medium text-red-700 dark:text-red-300">
-                    {deleteError}
-                  </div>
-                )}
-                <div className="mt-3 flex gap-2">
-                  <button
-                    type="button"
-                    onClick={handleDeleteGroup}
-                    disabled={isDeleting}
-                    className="flex-1 rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
-                  >
-                    {isDeleting ? 'Destroying...' : 'Destroy Group'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setGroupPendingDelete(null);
-                      setDeleteConfirmation('');
-                      setDeleteError(null);
-                    }}
-                    className="rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-
-      {/* Footer */}
-      <div className="sticky bottom-0 p-4 border-t border-gray-200 dark:border-gray-800 space-y-1 bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur">
-        <button
-          onClick={onOpenAgentAdmin}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-        >
-          <ShieldCheck size={16} />
-          <span className="text-sm font-medium">Agent Admin</span>
-        </button>
-        {onOpenSchemaWorkshop && (
-          <button
-            onClick={onOpenSchemaWorkshop}
-            className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-          >
-            <Layers size={16} />
-            <span className="text-sm font-medium">Schema Workshop</span>
-          </button>
-        )}
-        <button
-          onClick={onOpenDecisionLog}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-        >
-          <ScrollText size={16} />
-          <span className="text-sm font-medium">Decision Log</span>
-        </button>
-        <button
-          onClick={onOpenSettings}
-          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
-            llmConfigured
-              ? 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
-              : 'text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20'
-          }`}
-        >
-          {llmConfigured ? (
-            <Settings size={16} />
+              <Plus size={18} />
+              New Rule Group
+            </button>
           ) : (
-            <AlertTriangle size={16} />
+            <div className="space-y-2">
+              <input
+                ref={nameInputRef}
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreate();
+                  if (e.key === 'Escape') handleCancel();
+                }}
+                placeholder="Group name *"
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 outline-none focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <input
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreate();
+                  if (e.key === 'Escape') handleCancel();
+                }}
+                placeholder="Description (optional)"
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 outline-none focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleCreate}
+                  disabled={!name.trim() || isSubmitting}
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+                >
+                  <Check size={14} />
+                  {isSubmitting ? 'Creating…' : 'Create'}
+                </button>
+                <button
+                  onClick={handleCancel}
+                  className="rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            </div>
           )}
-          <span className="text-sm font-medium">
+        </div>
+
+        {/* Groups List */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-1">
+          {groups.length > 0 && (
+            <div className="pb-2 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              Rule Groups
+            </div>
+          )}
+
+          {groups.map((group) => (
+            <div key={group.id} className="space-y-2">
+              <div
+                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors ${
+                  selectedGroupId === group.id
+                    ? 'bg-blue-50/80 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300'
+                    : 'text-gray-600 hover:bg-white/60 dark:text-gray-400 dark:hover:bg-white/5'
+                }`}
+              >
+                <button
+                  onClick={() => {
+                    onSelectGroup(group.id);
+                    onClose();
+                  }}
+                  className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                >
+                  <ListTodo size={16} className="flex-shrink-0" />
+                  <div className="flex-1 overflow-hidden">
+                    <div className="truncate text-sm font-medium">{group.name}</div>
+                    {group.description && (
+                      <div className="truncate text-xs opacity-60">{group.description}</div>
+                    )}
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  aria-label="Destroy rule group"
+                  onClick={() => openDeleteFlow(group)}
+                  className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-300"
+                >
+                  <Trash2 size={15} />
+                </button>
+              </div>
+
+              {groupPendingDelete?.id === group.id && (
+                <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm dark:border-red-900/40 dark:bg-red-950/20">
+                  <div className="font-semibold text-red-800 dark:text-red-200">
+                    Destroy rule group
+                  </div>
+                  <p className="mt-1 text-xs text-red-700 dark:text-red-300">
+                    This permanently removes the group and every rule inside it.
+                  </p>
+                  <p className="mt-2 text-xs text-red-700 dark:text-red-300">
+                    Type <span className="font-semibold">{group.name}</span> to confirm.
+                  </p>
+                  <input
+                    ref={deleteConfirmInputRef}
+                    type="text"
+                    value={deleteConfirmation}
+                    onChange={(e) => setDeleteConfirmation(e.target.value)}
+                    placeholder="Exact group name"
+                    className="mt-3 w-full rounded-lg border border-red-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none focus:ring-2 focus:ring-red-500 dark:border-red-900/40 dark:bg-gray-900 dark:text-gray-100"
+                  />
+                  <input
+                    type="password"
+                    value={adminToken}
+                    onChange={(e) => setAdminToken(e.target.value)}
+                    placeholder="Admin token (only if server requires it)"
+                    className="mt-2 w-full rounded-lg border border-red-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none focus:ring-2 focus:ring-red-500 dark:border-red-900/40 dark:bg-gray-900 dark:text-gray-100"
+                  />
+                  {deleteError && (
+                    <div className="mt-2 text-xs font-medium text-red-700 dark:text-red-300">
+                      {deleteError}
+                    </div>
+                  )}
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={handleDeleteGroup}
+                      disabled={isDeleting}
+                      className="flex-1 rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                    >
+                      {isDeleting ? 'Destroying…' : 'Destroy Group'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setGroupPendingDelete(null);
+                        setDeleteConfirmation('');
+                        setDeleteError(null);
+                      }}
+                      className="rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-white/30 bg-white/60 p-4 backdrop-blur-sm dark:border-white/10 dark:bg-gray-950/60 space-y-0.5">
+          <button
+            onClick={() => { onOpenDashboard(); onClose(); }}
+            className={`${footerBtnBase} ${activeView === 'dashboard' ? footerBtnActive : footerBtnIdle}`}
+          >
+            <LayoutDashboard size={16} />
+            Dashboard
+          </button>
+          <button
+            onClick={() => { onOpenAgentAdmin(); onClose(); }}
+            className={`${footerBtnBase} ${activeView === 'agent-admin' ? footerBtnActive : footerBtnIdle}`}
+          >
+            <ShieldCheck size={16} />
+            Agent Admin
+          </button>
+          {onOpenSchemaWorkshop && (
+            <button
+              onClick={() => { onOpenSchemaWorkshop(); onClose(); }}
+              className={`${footerBtnBase} ${activeView === 'schema-workshop' ? footerBtnActive : footerBtnIdle}`}
+            >
+              <Layers size={16} />
+              Schema Workshop
+            </button>
+          )}
+          <button
+            onClick={() => { onOpenDecisionLog(); onClose(); }}
+            className={`${footerBtnBase} ${activeView === 'decision-log' ? footerBtnActive : footerBtnIdle}`}
+          >
+            <ScrollText size={16} />
+            Decision Log
+          </button>
+          <button
+            onClick={() => { onOpenSettings(); onClose(); }}
+            className={`${footerBtnBase} ${
+              !llmConfigured
+                ? 'text-amber-600 hover:bg-amber-50/60 dark:text-amber-400 dark:hover:bg-amber-900/10'
+                : footerBtnIdle
+            }`}
+          >
+            {llmConfigured ? <Settings size={16} /> : <AlertTriangle size={16} />}
             {llmConfigured ? 'LLM Settings' : 'Configure LLM'}
-          </span>
-        </button>
-        <button
-          onClick={toggleDarkMode}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-        >
-          {isDarkMode ? <Sun size={16} /> : <Moon size={16} />}
-          <span className="text-sm font-medium">{isDarkMode ? 'Light Mode' : 'Dark Mode'}</span>
-        </button>
+          </button>
+          <button
+            onClick={toggleDarkMode}
+            className={`${footerBtnBase} ${footerBtnIdle}`}
+          >
+            {isDarkMode ? <Sun size={16} /> : <Moon size={16} />}
+            {isDarkMode ? 'Light Mode' : 'Dark Mode'}
+          </button>
+        </div>
       </div>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- New `Dashboard.tsx` is now the default landing screen: shows Rule Engine / Decision Center health, stat cards, decision outcome breakdown with progress bars, inline pending-approval actions, and a recent-decisions table (desktop) / card list (mobile)
- Sidebar redesigned from a fixed desktop panel into a glassmorphism burger-menu slide-over overlay — single rendering path across all screen sizes
- Persistent top header bar added with hamburger toggle and breadcrumb navigation (`Unreal Objects › View › Group`)

## Changes
- `ui/src/components/Dashboard.tsx` — new file; auto-refreshes every 30 s via `Promise.allSettled`
- `ui/src/components/Sidebar.tsx` — glassmorphism overlay (`bg-white/85 backdrop-blur-xl`), new `isOpen`/`onClose`/`activeView`/`onOpenDashboard` props
- `ui/src/App.tsx` — persistent header, `sidebarOpen` state, default view changed to `dashboard`, simplified `EmptyState`
- `ui/src/api.ts` — `fetchRuleEngineHealth`, `fetchDecisionCenterHealth`, `fetchPendingApprovals`, `submitApprovalDecision`, `PendingApproval` interface
- `CLAUDE.md` — React UI section updated to document Dashboard and new sidebar behaviour
- `changelog/changelog_2026-04-13-2.md` — full session changelog

## Code Quality
- Tests: PASSED (310 passed, 0 errors)
- Linting: PASSED (0 errors, 2 warnings — both pre-existing in AgentAdminPanel.tsx)

## Open Items
- Verify `GET /v1/pending` and `POST /v1/decide/{id}/approve` are implemented on the Decision Center with the expected request/response shapes
- Pre-existing `react-hooks/exhaustive-deps` warnings in `AgentAdminPanel.tsx` remain unaddressed

---
Generated by day-closing agent